### PR TITLE
allows sane truthy/falsey values to get coerced to their respective boolean

### DIFF
--- a/lib/schemattr/dsl.rb
+++ b/lib/schemattr/dsl.rb
@@ -44,8 +44,8 @@ module Schemattr
 
     def boolean(name, options = {})
       _define name, true, options, setter: lambda { |val|
-        val = false if val == "false"
-        sync_value(self[name] = !!val, options[:sync])
+        bool = ActiveRecord::Type::Boolean.new.type_cast_from_user(val)
+        sync_value(self[name] = bool, options[:sync])
       }
     end
 

--- a/spec/schemattr/active_record_extension_spec.rb
+++ b/spec/schemattr/active_record_extension_spec.rb
@@ -59,12 +59,26 @@ describe Schemattr::ActiveRecordExtension do
 
     it "forces setting boolean fields to boolean values" do
       subject.settings = { skier: "foo", active: "true" }
-      expect(subject.settings.skier).to eq(true)
+      expect(subject.settings.skier).to eq(false)
 
       expect(subject.settings.active).to eq(true)
       expect(subject.settings.active?).to eq(true)
       expect(subject.active).to eq(true)
       expect(subject.active?).to eq(true)
+    end
+
+    it "coerces sane truthy/falsey values to acutal booleans" do
+      subject.update_attributes(settings: { active: "1" })
+      expect(subject.settings.active).to eq(true)
+
+      subject.update_attributes(settings: { active: "0" })
+      expect(subject.settings.active).to eq(false)
+
+      subject.update_attributes(settings: { active: "on" })
+      expect(subject.settings.active).to eq(true)
+
+      subject.update_attributes(settings: { active: "off" })
+      expect(subject.settings.active).to eq(false)
     end
 
     it "raises an exception if the value isn't a hash" do


### PR DESCRIPTION
apparently this method is going to be deprecated in Rails 5 (they suggest you do it yourself).  however, it still seems pretty reasonable to me in general. Here are the (sane) values it accepts.

ActiveRecord::ConnectionAdapters::Column::TRUE_VALUES
=> [true, 1, "1", "t", "T", "true", "TRUE", "on", "ON"]
ActiveRecord::ConnectionAdapters::Column::FALSE_VALUES
=> [false, 0, "0", "f", "F", "false", "FALSE", "off", "OFF"]
