### PR TITLE
Deprecate from option for a more explicit value_from

### DIFF
--- a/lib/schemattr/version.rb
+++ b/lib/schemattr/version.rb
@@ -1,3 +1,3 @@
 module Schemattr
-  VERSION = "0.1.0"
+  VERSION = "0.1.1"
 end


### PR DESCRIPTION
We ran into the `from` option at work, and we had no idea what the hell it meant and had to look it up in the documentation. I thought maybe renaming it would help make it more obvious.

Does this make me an open-source contributor now?